### PR TITLE
feat: POST visitor identity instead of cookie/header injection

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
 		'^log$': '<rootDir>/tests/__mocks__/log.js',
 		'^http-request$': '<rootDir>/tests/__mocks__/http-request.js',
 		'^create-response$': '<rootDir>/tests/__mocks__/create-response.js',
+		'context-manifest\\.json$': '<rootDir>/tests/fixtures/context-manifest.json',
 	},
 	setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
 	collectCoverageFrom: [

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,34 @@ To use custom values, either:
 
 The EdgeWorker still **GET**s the Uniform route composition so that fetch can be cached. The personalized response returned to the client is not cached.
 
+```mermaid
+flowchart LR
+  Client[Client / device]
+  EW[EdgeWorker<br/>responseProvider]
+  Cache[(Akamai cache<br/>for Uniform GET)]
+  Uniform[Uniform route API]
+  Client -->|GET cookies + x-quirk-*| EW
+  Client -->|POST JSON body| EW
+  EW -->|GET /api/v1/route<br/>cacheable| Cache
+  Cache --> Uniform
+  EW -->|personalized JSON<br/>not cached| Client
+```
+
+How visitor identity is chosen:
+
+```mermaid
+flowchart TD
+  A[Incoming request] --> B{Method is POST<br/>and body is non-empty?}
+  B -->|No| C[Read ufvd / ufvdqk cookies<br/>and x-quirk-* headers]
+  B -->|Yes| D{Body ≤ 2000 chars<br/>and valid JSON?}
+  D -->|No| E[400]
+  D -->|Yes| F[Use body: quirks, device,<br/>scores, tests, enrichments, events]
+  C --> G[Personalize composition]
+  F --> G
+  G --> H[GET Uniform composition]
+  H --> I[Return personalized JSON<br/>x-uniform-visitor-source]
+```
+
 ### Default: CDP / cookie injection
 
 `GET /api/v1/route?...` with:
@@ -44,9 +72,55 @@ The EdgeWorker still **GET**s the Uniform route composition so that fetch can be
 - `ufvd` / `ufvdqk` cookies (visitor scores, tests, quirks)
 - `x-quirk-*` headers (device / CDP quirks)
 
+```mermaid
+sequenceDiagram
+  participant Device
+  participant CDP as CDP / Akamai
+  participant EW as EdgeWorker
+  participant Cache as Akamai cache
+  participant Uniform as Uniform API
+
+  Device->>CDP: page/app request
+  CDP->>CDP: inject ufvd cookie and x-quirk-* headers
+  CDP->>EW: GET /api/v1/route
+  EW->>EW: read cookies + headers
+  EW->>Cache: GET composition
+  alt cache hit
+    Cache-->>EW: cached composition
+  else cache miss
+    Cache->>Uniform: GET composition
+    Uniform-->>Cache: composition JSON
+    Cache-->>EW: composition JSON
+  end
+  EW->>EW: personalize with cookie scores and quirks
+  EW-->>Device: personalized JSON<br/>x-uniform-visitor-source: cookies
+```
+
 ### Side option: client-supplied JSON body
 
 Because this worker controls the request the device makes, the client can **POST** the same visitor data instead of relying on cookie or header injection. `responseProvider` reads the body (quirks, scores, tests, device, enrichments, events), encodes scores/tests into the existing Uniform cookie format internally, and still fetches Uniform with GET.
+
+```mermaid
+sequenceDiagram
+  participant Device
+  participant EW as EdgeWorker
+  participant Cache as Akamai cache
+  participant Uniform as Uniform API
+
+  Device->>EW: POST /api/v1/route<br/>JSON body with quirks, device, scores
+  EW->>EW: parse body (max 2000 chars)
+  Note over Device,EW: cookies and x-quirk-* headers are ignored
+  EW->>Cache: GET composition
+  alt cache hit
+    Cache-->>EW: cached composition
+  else cache miss
+    Cache->>Uniform: GET composition
+    Uniform-->>Cache: composition JSON
+    Cache-->>EW: composition JSON
+  end
+  EW->>EW: personalize with client-supplied data
+  EW-->>Device: personalized JSON<br/>x-uniform-visitor-source: client-body
+```
 
 Keep the JSON body at **2000 characters or fewer**. Oversized or invalid JSON returns `400`.
 

--- a/readme.md
+++ b/readme.md
@@ -31,4 +31,49 @@ The scripts will use default values if environment variables are not set:
 
 To use custom values, either:
 1. Set them in your `.env` file, or
-2. Pass them inline:
+2. Pass them inline.
+
+## Visitor identity: cookies (default) or POST body
+
+The EdgeWorker still **GET**s the Uniform route composition so that fetch can be cached. The personalized response returned to the client is not cached.
+
+### Default: CDP / cookie injection
+
+`GET /api/v1/route?...` with:
+
+- `ufvd` / `ufvdqk` cookies (visitor scores, tests, quirks)
+- `x-quirk-*` headers (device / CDP quirks)
+
+### Side option: client-supplied JSON body
+
+Because this worker controls the request the device makes, the client can **POST** the same visitor data instead of relying on cookie or header injection. `responseProvider` reads the body (quirks, scores, tests, device, enrichments, events), encodes scores/tests into the existing Uniform cookie format internally, and still fetches Uniform with GET.
+
+Keep the JSON body at **2000 characters or fewer**. Oversized or invalid JSON returns `400`.
+
+```bash
+curl -X POST 'https://<ew-host>/api/v1/route?path=/' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "quirks": { "role": "developer" },
+    "device": { "os": "ios", "type": "phone" },
+    "scores": { "isdevelopersignal": 10 },
+    "tests": { "mytest": "var1" },
+    "enrichments": [{ "cat": "audience", "key": "dev", "str": 10 }],
+    "events": [{ "event": "app_open" }]
+  }'
+```
+
+```ts
+await fetch(`${ewHost}/api/v1/route?path=/`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    quirks: { role: 'developer' },
+    device: { os: 'ios', type: 'phone' },
+    scores: { isdevelopersignal: 10 },
+    tests: { mytest: 'var1' },
+  }),
+});
+```
+
+An empty POST body falls back to cookies and `x-quirk-*` headers. A non-empty POST body is the source of truth and ignores injected cookies/headers.

--- a/readme.md
+++ b/readme.md
@@ -76,4 +76,4 @@ await fetch(`${ewHost}/api/v1/route?path=/`, {
 });
 ```
 
-An empty POST body falls back to cookies and `x-quirk-*` headers. A non-empty POST body is the source of truth and ignores injected cookies/headers.
+An empty POST body falls back to cookies and `x-quirk-*` headers. A non-empty POST body is the source of truth and ignores injected cookies/headers. Successful responses include `x-uniform-visitor-source: client-body` or `cookies` so you can see which path ran.

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,22 +8,26 @@ import {
 	mapSlotToPersonalizedVariations,
 	mapSlotToTestVariations,
 } from '@uniformdev/canvas';
-import { Context, ManifestV2, CookieTransitionDataStore, CookieTransitionDataStoreOptions } from '@uniformdev/context';
+import {
+	Context,
+	ManifestV2,
+	CookieTransitionDataStore,
+	type EnrichmentData,
+	type EventData,
+	type Quirks,
+} from '@uniformdev/context';
 import manifest from './context-manifest.json';
 import { walkNodeTree } from '@uniformdev/canvas';
 import { CANVAS_TEST_SLOT } from '@uniformdev/canvas';
 import { httpRequest } from 'http-request';
 import { logger } from 'log';
 import { createResponse } from 'create-response';
+import { resolveVisitorIdentity } from './visitorPayload';
 
 export async function responseProvider(request: EW.ResponseProviderRequest) {
 	try {
 		const projectId = request.getVariable('PMUSER_UNIFORM_PROJECTID');
 		const apiKey = request.getVariable('PMUSER_UNIFORM_API_KEY');
-
-		//	logger.log('Debug: Starting request processing');
-		//	logger.log(`Debug: ProjectId: ${projectId}`);
-		//	logger.log(`Debug: Original URL: ${request.url}`);
 
 		if (!projectId) {
 			return createResponse(500, { 'Content-Type': 'text/html' }, '<html><body><h1>ProjectId is undefined</h1></body></html>');
@@ -32,46 +36,26 @@ export async function responseProvider(request: EW.ResponseProviderRequest) {
 			return createResponse(500, { 'Content-Type': 'text/html' }, '<html><body><h1>ApiKey is undefined</h1></body></html>');
 		}
 
-		// Parse URL manually
+		const visitorResult = await resolveVisitorIdentity(request);
+		if (!visitorResult.ok) {
+			return createResponse(visitorResult.status, { 'Content-Type': 'application/json' }, JSON.stringify({ error: visitorResult.message }));
+		}
+
+		const { identity } = visitorResult;
+
+		if (identity.source === 'cookies') {
+			const cookieHeader = request.getHeader('Cookie')?.[0] || '';
+			const cookies = cookieHeader.split(';').map((cookie) => cookie.trim());
+			for (const cookie of cookies) {
+				logger.log('individual cookie', cookie);
+			}
+		}
+
 		const originalUrl = request.url;
-		//	logger.log(`Debug: Original URL: ${originalUrl}`);
 		const [path, search] = originalUrl.split('?');
-
-		// Construct URL with explicit protocol and hostname
 		const uniformUrl = `https://uniform.global${path}?${search}`;
-		//	logger.log(`Debug: Uniform URL: ${uniformUrl}`);
 
-		// Extract quirks from headers
-		const quirks: Record<string, string> = {};
-		const headers = request.getHeaders();
-		for (const headerName in headers) {
-			if (headerName.startsWith('x-quirk-')) {
-				const headerValue = headers[headerName];
-				if (headerValue && headerValue.length > 0) {
-					quirks[headerName.replace('x-quirk-', '')] = headerValue[0];
-				}
-			}
-		}
-
-		// Extract ufvd cookie value
-		const cookieHeader = request.getHeader('Cookie')?.[0] || '';
-		let ufvdCookieValue = '';
-		let quirkCookieValue = '';
-
-		// Split the cookies string into individual cookies
-		const cookies = cookieHeader.split(';').map((cookie) => cookie.trim());
-
-		// Extract values from individual cookies
-		for (const cookie of cookies) {
-			logger.log('individual cookie', cookie);
-			if (cookie.startsWith('ufvd=')) {
-				ufvdCookieValue = cookie.substring(5);
-			} else if (cookie.startsWith('ufvdqk=')) {
-				quirkCookieValue = cookie.substring(7);
-			}
-		}
-
-		// Fetch the response and segment data concurrently
+		// Outbound fetch stays GET so Property Manager can cache the Uniform composition.
 		const requestOptions = {
 			headers: {
 				'x-api-key': apiKey,
@@ -84,37 +68,31 @@ export async function responseProvider(request: EW.ResponseProviderRequest) {
 			timeout: 5000,
 		};
 
-		//	logger.log('Debug: Sending request to Uniform');
 		const fetchResponse = await httpRequest(uniformUrl, {
 			...requestOptions,
 		});
-		//	logger.log(`Debug: Response status: ${fetchResponse.status}`);
 
 		const responseText = await fetchResponse.text();
-		//	logger.log(`Debug: Response body: ${responseText}`);
 
-		// Check if response is OK and URL is valid
 		if (fetchResponse.ok && path.toLowerCase() === '/api/v1/route') {
 			const route: RouteGetResponse = JSON.parse(responseText);
-			//	logger.log('Debug: Successfully parsed response JSON');
 
 			if (route.type === 'composition') {
 				await processComposition({
 					route,
-					quirks,
-					cookieValue: ufvdCookieValue,
-					quirkCookieValue: quirkCookieValue,
+					quirks: identity.quirks,
+					cookieValue: identity.cookieValue,
+					quirkCookieValue: identity.quirkCookieValue,
+					enrichments: identity.enrichments,
+					events: identity.events,
 				});
 
 				return createResponse(200, { 'Content-Type': 'application/json' }, JSON.stringify(route));
 			}
 		}
 
-		// If we get here, something went wrong
-		//logger.log(`Debug: Falling through to default response. Status: ${fetchResponse.status}`);
 		return createResponse(fetchResponse.status, { 'Content-Type': 'application/json' }, responseText);
 	} catch (error) {
-		//logger.log(`Debug: Error caught: ${error}`);
 		return createResponse(500, { 'Content-Type': 'text/html' }, `<html><body><h1>Internal Server Error: ${error}</h1></body></html>`);
 	}
 }
@@ -124,11 +102,15 @@ export const processComposition = async ({
 	quirks,
 	cookieValue,
 	quirkCookieValue,
+	enrichments,
+	events,
 }: {
 	route: RouteGetResponseComposition;
-	quirks: Record<string, string>;
+	quirks: Quirks;
 	cookieValue?: string;
 	quirkCookieValue?: string;
+	enrichments?: EnrichmentData[];
+	events?: EventData[];
 }) => {
 	const context = new Context({
 		manifest: manifest as ManifestV2,
@@ -142,11 +124,19 @@ export const processComposition = async ({
 		}),
 	});
 
-	await context.update({
+	const update: { quirks: Quirks; enrichments?: EnrichmentData[]; events?: EventData[] } = {
 		quirks: {
 			...quirks,
 		},
-	});
+	};
+	if (enrichments?.length) {
+		update.enrichments = enrichments;
+	}
+	if (events?.length) {
+		update.events = events;
+	}
+
+	await context.update(update);
 
 	walkNodeTree(route.compositionApiResponse.composition, async (treeNode) => {
 		if (treeNode.type === 'component') {
@@ -173,19 +163,14 @@ export const processComposition = async ({
 
 				const mapped = mapSlotToPersonalizedVariations(slot);
 
-				const { variations, personalized } = context.personalize({
+				const { variations } = context.personalize({
 					name: trackingEventName.value ?? 'Untitled Personalization',
 					variations: mapped,
 					take: parsedCount,
 					algorithm: algorithm?.value,
 				});
 
-
-				// Fix: Check if personalization actually found a match
-				// When algorithm finds no match, personalized will be false
-				// even if variations array is populated (which was the bug)
-
-				if (variations.length===0) {
+				if (variations.length === 0) {
 					actions.remove();
 				} else {
 					const [first, ...rest] = variations;
@@ -222,13 +207,11 @@ export const processComposition = async ({
 				if (!result) {
 					actions.remove();
 				} else {
-					// Clean up test system properties
 					const cleanTestVariant = (variant: any) => {
 						const cleaned = { ...variant };
 						if (cleaned.parameters) {
 							delete cleaned.parameters.$tstVrnt;
 						}
-						// Also remove test-specific metadata
 						delete cleaned.id;
 						delete cleaned.testDistribution;
 						return cleaned;

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,7 +87,14 @@ export async function responseProvider(request: EW.ResponseProviderRequest) {
 					events: identity.events,
 				});
 
-				return createResponse(200, { 'Content-Type': 'application/json' }, JSON.stringify(route));
+				return createResponse(
+					200,
+					{
+						'Content-Type': 'application/json',
+						'x-uniform-visitor-source': identity.source,
+					},
+					JSON.stringify(route)
+				);
 			}
 		}
 

--- a/src/visitorPayload.ts
+++ b/src/visitorPayload.ts
@@ -1,0 +1,279 @@
+import {
+	emptyVisitorData,
+	serializeCookie,
+	serializeQuirks,
+	type EnrichmentData,
+	type EventData,
+	type Quirks,
+	type ScoreVector,
+	type Tests,
+} from '@uniformdev/context';
+
+/**
+ * Showcase limit for the client-supplied visitor JSON body.
+ * Akamai allows much larger request bodies in responseProvider; this cap
+ * keeps the payload in cookie-replacement territory (device, scores, quirks).
+ */
+export const CLIENT_VISITOR_BODY_MAX_CHARS = 2000;
+
+export type ClientVisitorPayload = {
+	/** Visitor quirks (role, geo, device attributes, etc.) */
+	quirks?: Quirks;
+	/** Convenience bag of device attributes, merged into quirks as strings */
+	device?: Record<string, string | number | boolean>;
+	/** Permanent visitor scores (same data the ufvd cookie would carry) */
+	scores?: ScoreVector;
+	/** Session scores */
+	sessionScores?: ScoreVector;
+	/** Sticky A/B test assignments: { [testName]: variantId } */
+	tests?: Tests;
+	/** Enrichments to apply via context.update (CDP / client events) */
+	enrichments?: EnrichmentData[];
+	/** Analytics events that may trigger event signals */
+	events?: EventData[];
+};
+
+export type ResolvedVisitorIdentity = {
+	source: 'client-body' | 'cookies';
+	quirks: Quirks;
+	cookieValue: string;
+	quirkCookieValue: string;
+	enrichments?: EnrichmentData[];
+	events?: EventData[];
+};
+
+export type ResolveVisitorResult =
+	| { ok: true; identity: ResolvedVisitorIdentity }
+	| { ok: false; status: 400; message: string };
+
+export type VisitorRequest = {
+	method?: string;
+	text?: () => Promise<string>;
+	getHeaders: () => { [key: string]: string[] };
+	getHeader: (name: string) => string[] | null;
+};
+
+export function parseVisitorBody(raw: string | undefined | null):
+	| { status: 'ok'; payload: ClientVisitorPayload }
+	| { status: 'empty' }
+	| { status: 'too-large' }
+	| { status: 'invalid-json' } {
+	const trimmed = raw?.trim() ?? '';
+	if (!trimmed) {
+		return { status: 'empty' };
+	}
+	if (trimmed.length > CLIENT_VISITOR_BODY_MAX_CHARS) {
+		return { status: 'too-large' };
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch {
+		return { status: 'invalid-json' };
+	}
+
+	if (!isPlainObject(parsed)) {
+		return { status: 'invalid-json' };
+	}
+
+	return { status: 'ok', payload: normalizeClientVisitorPayload(parsed) };
+}
+
+export function visitorFromClientPayload(payload: ClientVisitorPayload): ResolvedVisitorIdentity {
+	const quirks: Quirks = { ...(payload.quirks ?? {}) };
+
+	if (payload.device) {
+		for (const [key, value] of Object.entries(payload.device)) {
+			if (value === undefined || value === null || quirks[key] !== undefined) {
+				continue;
+			}
+			quirks[key] = String(value);
+		}
+	}
+
+	const visitorData = {
+		...emptyVisitorData(),
+		quirks,
+		scores: payload.scores ?? {},
+		sessionScores: payload.sessionScores ?? {},
+		tests: payload.tests ?? {},
+	};
+
+	return {
+		source: 'client-body',
+		quirks,
+		cookieValue: serializeCookie(visitorData),
+		quirkCookieValue: serializeQuirks(quirks),
+		enrichments: payload.enrichments,
+		events: payload.events,
+	};
+}
+
+export function visitorFromCookiesAndHeaders(request: VisitorRequest): ResolvedVisitorIdentity {
+	const quirks = extractHeaderQuirks(request.getHeaders());
+	const cookieHeader = request.getHeader('Cookie')?.[0] || '';
+	const { ufvdCookieValue, quirkCookieValue } = extractUniformCookies(cookieHeader);
+
+	return {
+		source: 'cookies',
+		quirks,
+		cookieValue: ufvdCookieValue,
+		quirkCookieValue,
+	};
+}
+
+export async function resolveVisitorIdentity(request: VisitorRequest): Promise<ResolveVisitorResult> {
+	const method = (request.method || 'GET').toUpperCase();
+
+	if (method === 'POST' && typeof request.text === 'function') {
+		const parsed = parseVisitorBody(await request.text());
+
+		if (parsed.status === 'too-large') {
+			return {
+				ok: false,
+				status: 400,
+				message: `Visitor body exceeds ${CLIENT_VISITOR_BODY_MAX_CHARS} characters`,
+			};
+		}
+
+		if (parsed.status === 'invalid-json') {
+			return {
+				ok: false,
+				status: 400,
+				message: 'Visitor body must be JSON object with quirks, scores, tests, enrichments, and/or events',
+			};
+		}
+
+		if (parsed.status === 'ok') {
+			return { ok: true, identity: visitorFromClientPayload(parsed.payload) };
+		}
+	}
+
+	return { ok: true, identity: visitorFromCookiesAndHeaders(request) };
+}
+
+export function extractHeaderQuirks(headers: { [key: string]: string[] }): Quirks {
+	const quirks: Quirks = {};
+	for (const headerName in headers) {
+		if (headerName.startsWith('x-quirk-')) {
+			const headerValue = headers[headerName];
+			if (headerValue && headerValue.length > 0) {
+				quirks[headerName.replace('x-quirk-', '')] = headerValue[0];
+			}
+		}
+	}
+	return quirks;
+}
+
+export function extractUniformCookies(cookieHeader: string): {
+	ufvdCookieValue: string;
+	quirkCookieValue: string;
+} {
+	let ufvdCookieValue = '';
+	let quirkCookieValue = '';
+	const cookies = cookieHeader.split(';').map((cookie) => cookie.trim());
+
+	for (const cookie of cookies) {
+		if (cookie.startsWith('ufvd=')) {
+			ufvdCookieValue = cookie.substring(5);
+		} else if (cookie.startsWith('ufvdqk=')) {
+			quirkCookieValue = cookie.substring(7);
+		}
+	}
+
+	return { ufvdCookieValue, quirkCookieValue };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asStringRecord(value: unknown): Record<string, string> | undefined {
+	if (!isPlainObject(value)) {
+		return undefined;
+	}
+	const result: Record<string, string> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		if (entry === undefined || entry === null) {
+			continue;
+		}
+		result[key] = String(entry);
+	}
+	return result;
+}
+
+function asNumberRecord(value: unknown): ScoreVector | undefined {
+	if (!isPlainObject(value)) {
+		return undefined;
+	}
+	const result: ScoreVector = {};
+	for (const [key, entry] of Object.entries(value)) {
+		const numeric = typeof entry === 'number' ? entry : Number(entry);
+		if (!Number.isFinite(numeric)) {
+			continue;
+		}
+		result[key] = numeric;
+	}
+	return result;
+}
+
+function asEnrichments(value: unknown): EnrichmentData[] | undefined {
+	if (!Array.isArray(value)) {
+		return undefined;
+	}
+	const enrichments: EnrichmentData[] = [];
+	for (const item of value) {
+		if (!isPlainObject(item)) {
+			continue;
+		}
+		if (typeof item.cat !== 'string' || typeof item.key !== 'string') {
+			continue;
+		}
+		const str = typeof item.str === 'number' ? item.str : Number(item.str);
+		if (!Number.isFinite(str)) {
+			continue;
+		}
+		enrichments.push({ cat: item.cat, key: item.key, str });
+	}
+	return enrichments;
+}
+
+function asEvents(value: unknown): EventData[] | undefined {
+	if (!Array.isArray(value)) {
+		return undefined;
+	}
+	const events: EventData[] = [];
+	for (const item of value) {
+		if (!isPlainObject(item) || typeof item.event !== 'string') {
+			continue;
+		}
+		events.push({ event: item.event });
+	}
+	return events;
+}
+
+function asDevice(value: unknown): Record<string, string | number | boolean> | undefined {
+	if (!isPlainObject(value)) {
+		return undefined;
+	}
+	const device: Record<string, string | number | boolean> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
+			device[key] = entry;
+		}
+	}
+	return device;
+}
+
+function normalizeClientVisitorPayload(value: Record<string, unknown>): ClientVisitorPayload {
+	return {
+		quirks: asStringRecord(value.quirks),
+		device: asDevice(value.device),
+		scores: asNumberRecord(value.scores),
+		sessionScores: asNumberRecord(value.sessionScores),
+		tests: asStringRecord(value.tests),
+		enrichments: asEnrichments(value.enrichments),
+		events: asEvents(value.events),
+	};
+}

--- a/src/visitorPayload.ts
+++ b/src/visitorPayload.ts
@@ -1,7 +1,6 @@
 import {
 	emptyVisitorData,
 	serializeCookie,
-	serializeQuirks,
 	type EnrichmentData,
 	type EventData,
 	type Quirks,
@@ -94,17 +93,20 @@ export function visitorFromClientPayload(payload: ClientVisitorPayload): Resolve
 
 	const visitorData = {
 		...emptyVisitorData(),
-		quirks,
+		quirks: {},
 		scores: payload.scores ?? {},
 		sessionScores: payload.sessionScores ?? {},
 		tests: payload.tests ?? {},
+		controlGroup: false,
 	};
 
 	return {
 		source: 'client-body',
 		quirks,
+		// Scores/tests use the ufvd cookie encoding. Quirks stay off the quirk
+		// cookie so context.update() sees them as new and signal criteria run.
 		cookieValue: serializeCookie(visitorData),
-		quirkCookieValue: serializeQuirks(quirks),
+		quirkCookieValue: '',
 		enrichments: payload.enrichments,
 		events: payload.events,
 	};

--- a/tests/fixtures/context-manifest.json
+++ b/tests/fixtures/context-manifest.json
@@ -1,0 +1,52 @@
+{
+	"project": {
+		"id": "test-project",
+		"pz": {
+			"control": 0,
+			"sig": {
+				"isdevelopersignal": {
+					"str": 50,
+					"cap": 50,
+					"dur": "p",
+					"crit": {
+						"type": "G",
+						"op": "&",
+						"clauses": [
+							{
+								"type": "QK",
+								"key": "role",
+								"match": {
+									"op": "=",
+									"rhs": "developer"
+								}
+							}
+						]
+					}
+				},
+				"ismarketersignal": {
+					"str": 50,
+					"cap": 50,
+					"dur": "p",
+					"crit": {
+						"type": "G",
+						"op": "&",
+						"clauses": [
+							{
+								"type": "QK",
+								"key": "role",
+								"match": {
+									"op": "=",
+									"rhs": "marketer"
+								}
+							}
+						]
+					}
+				}
+			}
+		},
+		"test": {
+			"mytest": {},
+			"mytest2": {}
+		}
+	}
+}

--- a/tests/processComposition.integration.test.ts
+++ b/tests/processComposition.integration.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@uniformdev/canvas';
 import manifest from '../src/context-manifest.json';
 import { processComposition } from '../src/main';
+import { visitorFromClientPayload } from '../src/visitorPayload';
 
 describe('processComposition Integration Tests', () => {
 	const testCookieValue = 'mytest-var1!mytest2-var2~ses1-x!ses2-1~vis1-fa~isdevelopersignal-10';
@@ -620,5 +621,45 @@ describe('processComposition Integration Tests', () => {
 		
 		// The cookie contains isdevelopersignal-10, which should be processed
 		// along with the quirk role=developer triggering the signal
+	});
+
+	describe('Client POST visitor body (no CDP cookie injection)', () => {
+		it('personalizes from client-supplied quirks and scores instead of ufvd cookies', async () => {
+			const tdPayload = {
+				type: 'composition' as const,
+				matchedRoute: '/',
+				dynamicInputs: {},
+				compositionApiResponse: {
+					composition: {
+						...comprehensivePayload.compositionApiResponse.composition,
+						slots: {
+							content: [comprehensivePayload.compositionApiResponse.composition.slots!.content[0]],
+						},
+					},
+					projectId: 'a3ccbf9a-f51d-4022-8e2f-3dd31d6cde9a',
+					state: 64,
+					created: '2025-02-17T23:59:39.080481+00:00',
+					modified: '2025-08-21T14:55:02.875463+00:00',
+					pattern: false,
+				},
+			};
+
+			const identity = visitorFromClientPayload({
+				quirks: { role: 'developer' },
+				device: { os: 'ios' },
+				scores: { isdevelopersignal: 10 },
+			});
+
+			await processComposition({
+				route: tdPayload,
+				quirks: identity.quirks,
+				cookieValue: identity.cookieValue,
+				quirkCookieValue: identity.quirkCookieValue,
+			});
+
+			const contentSlot = tdPayload.compositionApiResponse.composition.slots.content;
+			expect(contentSlot).toHaveLength(1);
+			expect(contentSlot[0].parameters?.title?.value).toBe('TD: Hero For Developers');
+		});
 	});
 });

--- a/tests/processComposition.integration.test.ts
+++ b/tests/processComposition.integration.test.ts
@@ -382,7 +382,9 @@ describe('processComposition Integration Tests', () => {
 		}
 	};
 
-
+	const tdPersonalizationNode = JSON.parse(
+		JSON.stringify(comprehensivePayload.compositionApiResponse.composition.slots!.content[0])
+	);
 
 	describe('Top-Down Personalization', () => {
 		it('should replace TD personalization with "TD: Hero For Developers"', async () => {
@@ -624,7 +626,7 @@ describe('processComposition Integration Tests', () => {
 	});
 
 	describe('Client POST visitor body (no CDP cookie injection)', () => {
-		it('personalizes from client-supplied quirks and scores instead of ufvd cookies', async () => {
+		it('personalizes from client-supplied quirks instead of ufvd cookies', async () => {
 			const tdPayload = {
 				type: 'composition' as const,
 				matchedRoute: '/',
@@ -633,7 +635,7 @@ describe('processComposition Integration Tests', () => {
 					composition: {
 						...comprehensivePayload.compositionApiResponse.composition,
 						slots: {
-							content: [comprehensivePayload.compositionApiResponse.composition.slots!.content[0]],
+							content: [JSON.parse(JSON.stringify(tdPersonalizationNode))],
 						},
 					},
 					projectId: 'a3ccbf9a-f51d-4022-8e2f-3dd31d6cde9a',
@@ -647,7 +649,42 @@ describe('processComposition Integration Tests', () => {
 			const identity = visitorFromClientPayload({
 				quirks: { role: 'developer' },
 				device: { os: 'ios' },
-				scores: { isdevelopersignal: 10 },
+			});
+
+			await processComposition({
+				route: tdPayload,
+				quirks: identity.quirks,
+				cookieValue: identity.cookieValue,
+				quirkCookieValue: identity.quirkCookieValue,
+			});
+
+			const contentSlot = tdPayload.compositionApiResponse.composition.slots.content;
+			expect(contentSlot).toHaveLength(1);
+			expect(contentSlot[0].parameters?.title?.value).toBe('TD: Hero For Developers');
+		});
+
+		it('personalizes from client-supplied scores without quirk or cookie injection', async () => {
+			const tdPayload = {
+				type: 'composition' as const,
+				matchedRoute: '/',
+				dynamicInputs: {},
+				compositionApiResponse: {
+					composition: {
+						...comprehensivePayload.compositionApiResponse.composition,
+						slots: {
+							content: [JSON.parse(JSON.stringify(tdPersonalizationNode))],
+						},
+					},
+					projectId: 'a3ccbf9a-f51d-4022-8e2f-3dd31d6cde9a',
+					state: 64,
+					created: '2025-02-17T23:59:39.080481+00:00',
+					modified: '2025-08-21T14:55:02.875463+00:00',
+					pattern: false,
+				},
+			};
+
+			const identity = visitorFromClientPayload({
+				scores: { isdevelopersignal: 50 },
 			});
 
 			await processComposition({

--- a/tests/responseProvider.test.ts
+++ b/tests/responseProvider.test.ts
@@ -1,0 +1,131 @@
+import { httpRequest } from 'http-request';
+import { createResponse } from 'create-response';
+import { responseProvider } from '../src/main';
+
+const httpRequestMock = httpRequest as jest.Mock;
+const createResponseMock = createResponse as jest.Mock;
+
+const compositionResponse = {
+	type: 'composition',
+	matchedRoute: '/',
+	dynamicInputs: {},
+	compositionApiResponse: {
+		composition: {
+			_name: 'Root',
+			_id: 'root',
+			type: 'page',
+			slots: {
+				content: [
+					{
+						type: '$personalization',
+						slots: {
+							pz: [
+								{
+									type: 'hero',
+									parameters: {
+										title: { type: 'text', value: 'TD: Hero For Developers' },
+										$pzCrit: {
+											type: '$pzCrit',
+											value: {
+												dim: 'isdevelopersignal',
+												crit: [{ l: 'isdevelopersignal', r: '10', op: '>' }],
+												name: 'TD:Developer',
+											},
+										},
+									},
+								},
+								{
+									type: 'hero',
+									parameters: {
+										title: { type: 'text', value: 'TD: Default Hero' },
+										$pzCrit: {
+											type: '$pzCrit',
+											value: { crit: [], name: 'TD:Default' },
+										},
+									},
+								},
+							],
+						},
+						parameters: {
+							count: { type: 'number', value: '1' },
+							trackingEventName: { type: 'text', value: 'Personalization with TD' },
+						},
+					},
+				],
+			},
+		},
+		projectId: 'test',
+		state: 64,
+		created: '2025-02-17T23:59:39.080481+00:00',
+		modified: '2025-08-21T14:55:02.875463+00:00',
+		pattern: false,
+	},
+};
+
+function createRequest(overrides: Partial<EW.ResponseProviderRequest> = {}): EW.ResponseProviderRequest {
+	return {
+		url: '/api/v1/route?path=/',
+		method: 'GET',
+		getVariable: (name: string) => {
+			if (name === 'PMUSER_UNIFORM_PROJECTID') return 'project-id';
+			if (name === 'PMUSER_UNIFORM_API_KEY') return 'api-key';
+			return undefined;
+		},
+		getHeaders: () => ({}),
+		getHeader: () => null,
+		text: async () => '',
+		json: async () => ({}),
+		...overrides,
+	} as EW.ResponseProviderRequest;
+}
+
+describe('responseProvider client body option', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		createResponseMock.mockImplementation((status, headers, body) => ({ status, headers, body }));
+		httpRequestMock.mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => JSON.stringify(compositionResponse),
+		});
+	});
+
+	it('personalizes a POST with visitor JSON and still fetches Uniform via GET', async () => {
+		const request = createRequest({
+			method: 'POST',
+			text: async () =>
+				JSON.stringify({
+					quirks: { role: 'developer' },
+					scores: { isdevelopersignal: 10 },
+					device: { os: 'ios' },
+				}),
+			getHeader: () => ['ufvd=ismarketersignal-50'],
+			getHeaders: () => ({ 'x-quirk-role': ['marketer'] }),
+		});
+
+		const response = await responseProvider(request);
+		const body = JSON.parse(response.body);
+
+		expect(httpRequestMock).toHaveBeenCalledWith(
+			'https://uniform.global/api/v1/route?path=/',
+			expect.objectContaining({ method: 'GET' })
+		);
+		expect(response.status).toBe(200);
+		expect(body.compositionApiResponse.composition.slots.content[0].parameters.title.value).toBe(
+			'TD: Hero For Developers'
+		);
+	});
+
+	it('rejects oversized POST visitor bodies', async () => {
+		const request = createRequest({
+			method: 'POST',
+			text: async () => JSON.stringify({ quirks: { blob: 'x'.repeat(2000) } }),
+		});
+
+		const response = await responseProvider(request);
+
+		expect(httpRequestMock).not.toHaveBeenCalled();
+		expect(response.status).toBe(400);
+		expect(JSON.parse(response.body).error).toMatch(/2000 characters/);
+	});
+});

--- a/tests/responseProvider.test.ts
+++ b/tests/responseProvider.test.ts
@@ -1,6 +1,9 @@
 import { httpRequest } from 'http-request';
 import { createResponse } from 'create-response';
+import { Context, CookieTransitionDataStore, type ManifestV2 } from '@uniformdev/context';
 import { responseProvider } from '../src/main';
+import { visitorFromClientPayload } from '../src/visitorPayload';
+import manifest from '../src/context-manifest.json';
 
 const httpRequestMock = httpRequest as jest.Mock;
 const createResponseMock = createResponse as jest.Mock;
@@ -12,8 +15,21 @@ const compositionResponse = {
 	compositionApiResponse: {
 		composition: {
 			_name: 'Root',
-			_id: 'root',
+			_id: '53973f04-30c4-41c0-aeb6-38d34c61b3a0',
+			_slug: '/',
 			type: 'page',
+			projectMapNodes: [
+				{
+					id: '80c60764-688e-4c32-a2c1-0632fa637cd7',
+					projectMapId: '0a49ceed-2b17-433e-97b2-b4a9e256d707',
+					path: '/',
+					locales: {},
+					data: {},
+				},
+			],
+			parameters: {
+				title: { type: 'text', value: 'Home Page' },
+			},
 			slots: {
 				content: [
 					{
@@ -54,13 +70,15 @@ const compositionResponse = {
 				],
 			},
 		},
-		projectId: 'test',
+		projectId: 'a3ccbf9a-f51d-4022-8e2f-3dd31d6cde9a',
 		state: 64,
 		created: '2025-02-17T23:59:39.080481+00:00',
 		modified: '2025-08-21T14:55:02.875463+00:00',
 		pattern: false,
 	},
 };
+
+type MockResponse = { status: number; headers: Record<string, string>; body: string };
 
 function createRequest(overrides: Partial<EW.ResponseProviderRequest> = {}): EW.ResponseProviderRequest {
 	return {
@@ -82,11 +100,38 @@ function createRequest(overrides: Partial<EW.ResponseProviderRequest> = {}): EW.
 describe('responseProvider client body option', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
-		createResponseMock.mockImplementation((status, headers, body) => ({ status, headers, body }));
+		createResponseMock.mockImplementation((status, headers, body) => ({ status, headers, body } as MockResponse));
 		httpRequestMock.mockResolvedValue({
 			ok: true,
 			status: 200,
 			text: async () => JSON.stringify(compositionResponse),
+		});
+	});
+
+	it('applies POST quirks as new context state so signals can score', async () => {
+		const identity = visitorFromClientPayload({
+			quirks: { role: 'developer' },
+			device: { os: 'ios' },
+		});
+		const context = new Context({
+			manifest: manifest as ManifestV2,
+			defaultConsent: true,
+			transitionStore: new CookieTransitionDataStore({
+				cookieName: 'ufvd',
+				serverCookieValue: identity.cookieValue,
+				quirkCookieName: 'ufvdqk',
+				quirkCookieValue: identity.quirkCookieValue,
+				experimental_quirksEnabled: true,
+			}),
+		});
+		await context.update({ quirks: identity.quirks });
+		expect({
+			quirks: identity.quirks,
+			scores: context.scores,
+			cookieValue: identity.cookieValue,
+		}).toMatchObject({
+			quirks: { role: 'developer' },
+			scores: { isdevelopersignal: 50 },
 		});
 	});
 
@@ -96,14 +141,13 @@ describe('responseProvider client body option', () => {
 			text: async () =>
 				JSON.stringify({
 					quirks: { role: 'developer' },
-					scores: { isdevelopersignal: 10 },
 					device: { os: 'ios' },
 				}),
 			getHeader: () => ['ufvd=ismarketersignal-50'],
 			getHeaders: () => ({ 'x-quirk-role': ['marketer'] }),
 		});
 
-		const response = await responseProvider(request);
+		const response = (await responseProvider(request)) as MockResponse;
 		const body = JSON.parse(response.body);
 
 		expect(httpRequestMock).toHaveBeenCalledWith(
@@ -111,9 +155,32 @@ describe('responseProvider client body option', () => {
 			expect.objectContaining({ method: 'GET' })
 		);
 		expect(response.status).toBe(200);
-		expect(body.compositionApiResponse.composition.slots.content[0].parameters.title.value).toBe(
-			'TD: Hero For Developers'
+		expect(response.headers['x-uniform-visitor-source']).toBe('client-body');
+		expect(body.compositionApiResponse.composition.slots.content[0]).toMatchObject({
+			type: 'hero',
+			parameters: { title: { value: 'TD: Hero For Developers' } },
+		});
+	});
+
+	it('still personalizes GET requests from cookies and x-quirk-* headers', async () => {
+		const request = createRequest({
+			method: 'GET',
+			getHeaders: () => ({ 'x-quirk-role': ['developer'] }),
+			getHeader: () => ['ufvd=isdevelopersignal-10'],
+		});
+
+		const response = (await responseProvider(request)) as MockResponse;
+		const body = JSON.parse(response.body);
+
+		expect(httpRequestMock).toHaveBeenCalledWith(
+			'https://uniform.global/api/v1/route?path=/',
+			expect.objectContaining({ method: 'GET' })
 		);
+		expect(response.headers['x-uniform-visitor-source']).toBe('cookies');
+		expect(body.compositionApiResponse.composition.slots.content[0]).toMatchObject({
+			type: 'hero',
+			parameters: { title: { value: 'TD: Hero For Developers' } },
+		});
 	});
 
 	it('rejects oversized POST visitor bodies', async () => {
@@ -122,7 +189,7 @@ describe('responseProvider client body option', () => {
 			text: async () => JSON.stringify({ quirks: { blob: 'x'.repeat(2000) } }),
 		});
 
-		const response = await responseProvider(request);
+		const response = (await responseProvider(request)) as MockResponse;
 
 		expect(httpRequestMock).not.toHaveBeenCalled();
 		expect(response.status).toBe(400);

--- a/tests/visitorPayload.test.ts
+++ b/tests/visitorPayload.test.ts
@@ -61,9 +61,8 @@ describe('visitorFromClientPayload', () => {
 		const decoded = parseScoreCookie(identity.cookieValue, identity.quirkCookieValue);
 		expect(decoded?.scores?.isdevelopersignal).toBe(10);
 		expect(decoded?.tests?.mytest).toBe('var1');
-		expect(decoded?.quirks?.role).toBe('developer');
 		expect(identity.cookieValue.length).toBeGreaterThan(0);
-		expect(identity.quirkCookieValue.length).toBeGreaterThan(0);
+		expect(identity.quirkCookieValue).toBe('');
 	});
 
 	it('flattens device attributes into quirks without overwriting explicit quirks', () => {
@@ -97,7 +96,7 @@ describe('resolveVisitorIdentity', () => {
 		expect(result.identity.source).toBe('client-body');
 		expect(result.identity.quirks).toEqual({ role: 'developer' });
 		expect(result.identity.cookieValue).not.toContain('ismarketersignal');
-		expect(parseScoreCookie(result.identity.cookieValue)?.scores.isdevelopersignal).toBe(10);
+		expect(parseScoreCookie(result.identity.cookieValue)?.scores?.isdevelopersignal).toBe(10);
 	});
 
 	it('falls back to cookies and x-quirk-* headers for GET', async () => {

--- a/tests/visitorPayload.test.ts
+++ b/tests/visitorPayload.test.ts
@@ -1,0 +1,174 @@
+import { parseScoreCookie } from '@uniformdev/context';
+import {
+	CLIENT_VISITOR_BODY_MAX_CHARS,
+	parseVisitorBody,
+	resolveVisitorIdentity,
+	visitorFromClientPayload,
+	visitorFromCookiesAndHeaders,
+} from '../src/visitorPayload';
+
+describe('parseVisitorBody', () => {
+	it('accepts quirks, scores, tests, device, enrichments, and events', () => {
+		const parsed = parseVisitorBody(
+			JSON.stringify({
+				quirks: { role: 'developer' },
+				device: { os: 'ios', type: 'phone', foldable: false },
+				scores: { isdevelopersignal: 10 },
+				sessionScores: { ses1: 2 },
+				tests: { mytest: 'var1' },
+				enrichments: [{ cat: 'audience', key: 'dev', str: 10 }],
+				events: [{ event: 'app_open' }],
+			})
+		);
+
+		expect(parsed.status).toBe('ok');
+		if (parsed.status !== 'ok') {
+			return;
+		}
+
+		expect(parsed.payload.quirks).toEqual({ role: 'developer' });
+		expect(parsed.payload.device).toEqual({ os: 'ios', type: 'phone', foldable: false });
+		expect(parsed.payload.scores).toEqual({ isdevelopersignal: 10 });
+		expect(parsed.payload.tests).toEqual({ mytest: 'var1' });
+		expect(parsed.payload.enrichments).toEqual([{ cat: 'audience', key: 'dev', str: 10 }]);
+		expect(parsed.payload.events).toEqual([{ event: 'app_open' }]);
+	});
+
+	it('rejects bodies over the showcase 2000 character cap', () => {
+		const payload = JSON.stringify({ quirks: { blob: 'x'.repeat(CLIENT_VISITOR_BODY_MAX_CHARS) } });
+		expect(payload.length).toBeGreaterThan(CLIENT_VISITOR_BODY_MAX_CHARS);
+		expect(parseVisitorBody(payload).status).toBe('too-large');
+	});
+
+	it('rejects invalid JSON and non-objects', () => {
+		expect(parseVisitorBody('not-json').status).toBe('invalid-json');
+		expect(parseVisitorBody('["nope"]').status).toBe('invalid-json');
+		expect(parseVisitorBody('').status).toBe('empty');
+	});
+});
+
+describe('visitorFromClientPayload', () => {
+	it('encodes scores and tests into the same cookie format CDP injection would use', () => {
+		const identity = visitorFromClientPayload({
+			quirks: { role: 'developer' },
+			scores: { isdevelopersignal: 10 },
+			tests: { mytest: 'var1' },
+		});
+
+		expect(identity.source).toBe('client-body');
+		expect(identity.quirks).toEqual({ role: 'developer' });
+
+		const decoded = parseScoreCookie(identity.cookieValue, identity.quirkCookieValue);
+		expect(decoded?.scores?.isdevelopersignal).toBe(10);
+		expect(decoded?.tests?.mytest).toBe('var1');
+		expect(decoded?.quirks?.role).toBe('developer');
+		expect(identity.cookieValue.length).toBeGreaterThan(0);
+		expect(identity.quirkCookieValue.length).toBeGreaterThan(0);
+	});
+
+	it('flattens device attributes into quirks without overwriting explicit quirks', () => {
+		const identity = visitorFromClientPayload({
+			quirks: { os: 'android' },
+			device: { os: 'ios', type: 'phone' },
+		});
+
+		expect(identity.quirks).toEqual({ os: 'android', type: 'phone' });
+	});
+});
+
+describe('resolveVisitorIdentity', () => {
+	it('uses POST JSON instead of cookies and quirk headers', async () => {
+		const result = await resolveVisitorIdentity({
+			method: 'POST',
+			text: async () =>
+				JSON.stringify({
+					quirks: { role: 'developer' },
+					scores: { isdevelopersignal: 10 },
+				}),
+			getHeaders: () => ({ 'x-quirk-role': ['marketer'] }),
+			getHeader: (name) => (name === 'Cookie' ? ['ufvd=ismarketersignal-50'] : null),
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) {
+			return;
+		}
+
+		expect(result.identity.source).toBe('client-body');
+		expect(result.identity.quirks).toEqual({ role: 'developer' });
+		expect(result.identity.cookieValue).not.toContain('ismarketersignal');
+		expect(parseScoreCookie(result.identity.cookieValue)?.scores.isdevelopersignal).toBe(10);
+	});
+
+	it('falls back to cookies and x-quirk-* headers for GET', async () => {
+		const result = await resolveVisitorIdentity({
+			method: 'GET',
+			getHeaders: () => ({ 'x-quirk-role': ['developer'] }),
+			getHeader: (name) =>
+				name === 'Cookie' ? ['session=abc; ufvd=isdevelopersignal-10; ufvdqk=country-us'] : null,
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) {
+			return;
+		}
+
+		expect(result.identity).toEqual({
+			source: 'cookies',
+			quirks: { role: 'developer' },
+			cookieValue: 'isdevelopersignal-10',
+			quirkCookieValue: 'country-us',
+		});
+	});
+
+	it('falls back to cookies when POST has an empty body', async () => {
+		const result = await resolveVisitorIdentity({
+			method: 'POST',
+			text: async () => '',
+			getHeaders: () => ({}),
+			getHeader: () => ['ufvd=isdevelopersignal-10'],
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) {
+			return;
+		}
+		expect(result.identity.source).toBe('cookies');
+		expect(result.identity.cookieValue).toBe('isdevelopersignal-10');
+	});
+
+	it('returns 400 for oversized or invalid POST bodies', async () => {
+		const tooLarge = await resolveVisitorIdentity({
+			method: 'POST',
+			text: async () => `{"quirks":{"blob":"${'x'.repeat(CLIENT_VISITOR_BODY_MAX_CHARS)}"}}`,
+			getHeaders: () => ({}),
+			getHeader: () => null,
+		});
+		expect(tooLarge).toMatchObject({ ok: false, status: 400 });
+
+		const invalid = await resolveVisitorIdentity({
+			method: 'POST',
+			text: async () => '{bad',
+			getHeaders: () => ({}),
+			getHeader: () => null,
+		});
+		expect(invalid).toMatchObject({ ok: false, status: 400 });
+	});
+});
+
+describe('visitorFromCookiesAndHeaders', () => {
+	it('reads x-quirk-* headers and ufvd cookies', () => {
+		const identity = visitorFromCookiesAndHeaders({
+			getHeaders: () => ({
+				'x-quirk-role': ['developer'],
+				accept: ['application/json'],
+			}),
+			getHeader: () => ['ufvd=mytest-var1; ufvdqk=role-developer'],
+		});
+
+		expect(identity.source).toBe('cookies');
+		expect(identity.quirks).toEqual({ role: 'developer' });
+		expect(identity.cookieValue).toBe('mytest-var1');
+		expect(identity.quirkCookieValue).toBe('role-developer');
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an optional `responseProvider` path so devices can send visitor data in a POST body instead of relying on CDP-injected `ufvd` cookies and `x-quirk-*` headers.

**Default (unchanged):** `GET` with `ufvd` / `ufvdqk` cookies and `x-quirk-*` headers.

**Side option:** `POST` JSON (max 2000 chars) with `quirks`, `device`, `scores`, `sessionScores`, `tests`, `enrichments`, and `events`. A non-empty POST body is the source of truth; cookies/headers are ignored. Empty POST still falls back to cookies.

The outbound Uniform composition fetch remains a **GET**, so Property Manager can still cache that subrequest. The personalized EW response is not cached.

Successful responses include `x-uniform-visitor-source: client-body` or `cookies`.

The README now includes mermaid diagrams for:
- both paths sharing the same cacheable Uniform GET
- how visitor identity is chosen
- CDP cookie/header injection vs client POST body

```bash
curl -X POST 'https://<ew-host>/api/v1/route?path=/' \
  -H 'Content-Type: application/json' \
  -d '{"quirks":{"role":"developer"},"device":{"os":"ios"},"scores":{"isdevelopersignal":50}}'
```

---

**Apply the same work on `context-as-a-service`** (this agent cannot push that repo):

```bash
cd /Users/artem/src/code/context-as-a-service/context-as-a-service
git checkout main && git pull
git checkout -b cursor/post-visitor-body-27eb
curl -fsSL 'https://raw.githubusercontent.com/uniform-collab/CaaS-akamai/cursor/post-visitor-body-27eb/context-as-a-service-post-visitor-body.patch' | git am
git push -u origin cursor/post-visitor-body-27eb
```

Then open a PR on `uniform-collab/context-as-a-service`. The patch is two commits: engine POST support, then parsers moved into each proxy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8213ae9f-146d-44b2-a57c-c690dc6427eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8213ae9f-146d-44b2-a57c-c690dc6427eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

